### PR TITLE
fixing add_lcsi not considering missing values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,6 @@ Encoding: UTF-8
 LazyData: true
 Imports:
     dplyr,
-    rlang,
     tidyr,
     magrittr,
     glue,

--- a/R/add_lcsi.R
+++ b/R/add_lcsi.R
@@ -10,8 +10,16 @@
 #' @param no_val A character value in the dataset associated with "No, have not used this coping strategy in the last 30 days."
 #' @param exhausted_val A character value in the dataset associated with "No, haven't used in the last 30 days because I've exhausted this coping strategy in the last 6 or 12 months."
 #' @param not_applicable_val A character value in the dataset associated with "This coping strategy is not applicable for the household.
+#' @param ignore_NA Default is FALSE. If set to TRUE, the missing values will be ignored.
 #'
 #' @return Returns a dataframe with added columns for LCSI indicators.
+#' - lcsi_x_yes : 1 means one of the of the x strategies was used (*yes_val*)
+#' - lcsi_x_exhaust: 1 means one of the x strategies was exhausted and could not be used (*exhausted_val*)
+#' - lcsi_x: 1 means one of the x strategies was if either used (*yes_val*) or exhausted (*exhausted_val*)
+#' Where x is stress, crisis or emergency
+#' - lcsi_cat_yes : the highest category between the lcsi_x_yes
+#' - lcsi_cat_exhast: the highest category between the lcsi_x_exhaust
+#' - lcsi_cat: the highest category between the lcsi_x
 #' @export
 #'
 #' @examples{

--- a/R/add_lcsi.R
+++ b/R/add_lcsi.R
@@ -44,7 +44,8 @@ add_lcsi <- function(.dataset,
                      yes_val = NULL,
                      no_val = NULL,
                      exhausted_val = NULL,
-                     not_applicable_val = NULL) {
+                     not_applicable_val = NULL,
+                     ignore_NA = FALSE) {
   df <- .dataset
 
   # If NULL, set a standard default values for LCSI responses.
@@ -82,6 +83,7 @@ add_lcsi <- function(.dataset,
     t() %>%
     c() %>%
     unique()
+  lcs_codes <- lcs_codes[!is.na(lcs_codes)]
 
   # Check 4: Number of unique values across LCSI variables must be <= 4.
 
@@ -195,6 +197,21 @@ add_lcsi <- function(.dataset,
         TRUE ~ NA_character_
       )
     )
+
+  if(ignore_NA == FALSE) {
+    which_na <- df %>%
+      dplyr::select(lcsi_stress1:lcsi_emergency3) %>%
+      is.na() %>%
+      rowSums() %>%
+      as.logical()
+
+    lcsi_added_cols <- c("lcsi_stress_yes", "lcsi_stress_exhaust", "lcsi_stress", "lcsi_crisis_yes",
+                         "lcsi_crisis_exhaust", "lcsi_crisis", "lcsi_emergency_yes",
+                         "lcsi_emergency_exhaust", "lcsi_emergency", "lcsi_cat_yes","lcsi_cat_exhaust",
+                         "lcsi_cat")
+
+    df[which_na,lcsi_added_cols] <- NA
+    }
 
   return(df)
 }

--- a/man/add_lcsi.Rd
+++ b/man/add_lcsi.Rd
@@ -12,7 +12,8 @@ add_lcsi(
   yes_val = NULL,
   no_val = NULL,
   exhausted_val = NULL,
-  not_applicable_val = NULL
+  not_applicable_val = NULL,
+  ignore_NA = FALSE
 )
 }
 \arguments{
@@ -31,9 +32,18 @@ add_lcsi(
 \item{exhausted_val}{A character value in the dataset associated with "No, haven't used in the last 30 days because I've exhausted this coping strategy in the last 6 or 12 months."}
 
 \item{not_applicable_val}{A character value in the dataset associated with "This coping strategy is not applicable for the household.}
+
+\item{ignore_NA}{Default is FALSE. If set to TRUE, the missing values will be ignored.}
 }
 \value{
 Returns a dataframe with added columns for LCSI indicators.
+- lcsi_x_yes : 1 means one of the of the x strategies was used (*yes_val*)
+- lcsi_x_exhaust: 1 means one of the x strategies was exhausted and could not be used (*exhausted_val*)
+- lcsi_x: 1 means one of the x strategies was if either used (*yes_val*) or exhausted (*exhausted_val*)
+Where x is stress, crisis or emergency
+- lcsi_cat_yes : the highest category between the lcsi_x_yes
+- lcsi_cat_exhast: the highest category between the lcsi_x_exhaust
+- lcsi_cat: the highest category between the lcsi_x
 }
 \description{
 Function to calculate Livelihood Coping Strategy Index (LCSI)

--- a/tests/testthat/test-add_lcsi.R
+++ b/tests/testthat/test-add_lcsi.R
@@ -87,15 +87,6 @@ testthat::test_that("testing add_lcsi", {
                         not_applicable_val = "Not Applicable"),
                output_data1)
 
-  # a <- add_lcsi(.dataset = input_data1,
-  #               lcsi_stress_vars = c("stress1", "stress2", "stress3", "stress4"),
-  #               lcsi_crisis_vars = c("crisis1", "crisis2", "crisis3"),
-  #               lcsi_emergency_vars = c("emergency1", "emergency2", "emergency3"),
-  #               yes_val = "Yes",
-  #               no_val = "No",
-  #               exhausted_val = "Exhausted",
-  #               not_applicable_val = "Not Applicable")
-
   # Test 2 - (happy path) - Correct number of columns and rows are returned.
 
   expect_equal(dim(add_lcsi(.dataset = input_data1,
@@ -197,5 +188,115 @@ testthat::test_that("testing add_lcsi", {
                                   no_val = "No",
                                   exhausted_val = "Exhausted",
                                   not_applicable_val = "Not Applicable"))
+
+})
+
+test_that("NA are handle correctly", {
+  #NA will return NA
+  test_data <- data.frame(
+    uuid = letters[1:2],
+    lcsi_option1 = c(NA, "yes"),
+    lcsi_option2 = c("yes", "yes"),
+    lcsi_option3 = c("yes", "yes"),
+    lcsi_option4 = c("yes", "yes"),
+    lcsi_option5 = c("yes", "yes"),
+    lcsi_option6 = c("yes", "yes"),
+    lcsi_option7 = c("yes", "yes"),
+    lcsi_option8 = c("yes", "yes"),
+    lcsi_option9 = c("yes", "yes"),
+    lcsi_option10 = c("yes", "yes")
+  )
+
+  expected_output <- test_data %>%
+    dplyr::mutate(lcsi_stress1 = lcsi_option1,
+                  lcsi_stress2 = lcsi_option2,
+                  lcsi_stress3 = lcsi_option3,
+                  lcsi_stress4 = lcsi_option4,
+                  lcsi_crisis1 = lcsi_option5,
+                  lcsi_crisis2 = lcsi_option6,
+                  lcsi_crisis3 = lcsi_option7,
+                  lcsi_emergency1 = lcsi_option8,
+                  lcsi_emergency2 = lcsi_option9,
+                  lcsi_emergency3 = lcsi_option10,
+                  lcsi_stress_yes = c(NA_character_, "1"),
+                  lcsi_stress_exhaust = c(NA_character_, "0"),
+                  lcsi_stress = c(NA_character_, "1"),
+                  lcsi_crisis_yes = c(NA_character_, "1"),
+                  lcsi_crisis_exhaust = c(NA_character_, "0"),
+                  lcsi_crisis = c(NA_character_, "1"),
+                  lcsi_emergency_yes = c(NA_character_, "1"),
+                  lcsi_emergency_exhaust = c(NA_character_, "0"),
+                  lcsi_emergency = c(NA_character_, "1"),
+                  lcsi_cat_yes = c(NA_character_, "Emergency"),
+                  lcsi_cat_exhaust = c(NA_character_, "None"),
+                  lcsi_cat = c(NA_character_, "Emergency"))
+
+  actual_output <- test_data %>% add_lcsi(
+    lcsi_stress_vars = c("lcsi_option1", "lcsi_option2", "lcsi_option3", "lcsi_option4"),
+    lcsi_crisis_vars = c("lcsi_option5", "lcsi_option6", "lcsi_option7"),
+    lcsi_emergency_vars = c("lcsi_option8", "lcsi_option9", "lcsi_option10"),
+    yes_val = "yes",
+    no_val = "no",
+    exhausted_val = "no_exhausted",
+    not_applicable_val = "not_applicable"
+  ) %>% suppressWarnings()
+
+  expect_equal(actual_output, expected_output)
+
+
+  #NA are ignored
+  test_data <- data.frame(
+    uuid = letters[1:5],
+    lcsi_option1 = c(NA, "yes", "no_had_no_need", "no_exhausted", "not_applicable")
+  )
+  test_data <- test_data %>%
+    dplyr::mutate(
+      lcsi_option2 = c("yes", NA, "no_exhausted", "not_applicable", "yes"),
+      lcsi_option3 = c("yes", "no_had_no_need", NA, "not_applicable", "yes"),
+      lcsi_option4 = c("yes", "no_had_no_need", "no_exhausted", NA, "yes"),
+      lcsi_option5 = c("yes", "no_had_no_need", "no_exhausted", "not_applicable", NA),
+      lcsi_option6 = lcsi_option1,
+      lcsi_option7 = lcsi_option1,
+      lcsi_option8 = lcsi_option1,
+      lcsi_option9 = lcsi_option1,
+      lcsi_option10 = lcsi_option1
+    )
+
+  expected_data <- test_data %>%
+    dplyr::mutate(lcsi_stress1 = lcsi_option1,
+                  lcsi_stress2 = lcsi_option2,
+                  lcsi_stress3 = lcsi_option3,
+                  lcsi_stress4 = lcsi_option4,
+                  lcsi_crisis1 = lcsi_option5,
+                  lcsi_crisis2 = lcsi_option6,
+                  lcsi_crisis3 = lcsi_option7,
+                  lcsi_emergency1 = lcsi_option8,
+                  lcsi_emergency2 = lcsi_option9,
+                  lcsi_emergency3 = lcsi_option10,
+                  lcsi_stress_yes = c("1", "1", "0", "0", "1"),
+                  lcsi_stress_exhaust = c("0", "0", "1", "1", "0"),
+                  lcsi_stress = c("1", "1", "1", "1", "1"),
+                  lcsi_crisis_yes = c("1", "1", "0", "0", "0"),
+                  lcsi_crisis_exhaust = c("0", "0", "1", "1", "0"),
+                  lcsi_crisis = c("1", "1", "1", "1", "0"),
+                  lcsi_emergency_yes = c("0", "1", "0", "0", "0"),
+                  lcsi_emergency_exhaust = c("0", "0", "0", "1", "0"),
+                  lcsi_emergency = c("0", "1", "0", "1", "0"),
+                  lcsi_cat_yes = c("Crisis", "Emergency", "None", "None", "Stress"),
+                  lcsi_cat_exhaust = c("None", "None", "Crisis", "Emergency", "None"),
+                  lcsi_cat = c("Crisis", "Emergency", "Crisis", "Emergency", "Stress"))
+
+  actual_output <- test_data %>% add_lcsi(
+    lcsi_stress_vars = c("lcsi_option1", "lcsi_option2", "lcsi_option3", "lcsi_option4"),
+    lcsi_crisis_vars = c("lcsi_option5", "lcsi_option6", "lcsi_option7"),
+    lcsi_emergency_vars = c("lcsi_option8", "lcsi_option9", "lcsi_option10"),
+    yes_val = "yes",
+    no_val = "no_had_no_need",
+    exhausted_val = "no_exhausted",
+    not_applicable_val = "not_applicable",
+    ignore_NA = TRUE
+  )
+
+  expect_equal(actual_output, expected_data)
 
 })


### PR DESCRIPTION
- Adding a fix so that the function still runs if there are missing values. They were considered as a 5th value. The default will now return NA when there is at least one missing value

- Also adding a new argument to ignore the missing value and still compute them.